### PR TITLE
Create youth user backend

### DIFF
--- a/.vscode/iisexpress.json
+++ b/.vscode/iisexpress.json
@@ -1,0 +1,6 @@
+{
+  "port": 12821,
+  "path": "c:\\Users\\liam.miller.INTRA\\Documents\\CoV-pwa\\Mobiilinutakortti",
+  "clr": "v4.0",
+  "protocol": "http"
+}

--- a/.vscode/iisexpress.json
+++ b/.vscode/iisexpress.json
@@ -1,6 +1,0 @@
-{
-  "port": 12821,
-  "path": "c:\\Users\\liam.miller.INTRA\\Documents\\CoV-pwa\\Mobiilinutakortti",
-  "clr": "v4.0",
-  "protocol": "http"
-}

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Post, Body, UsePipes, ValidationPipe, Get, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, UsePipes, ValidationPipe, Get, UseGuards, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { RegisterAdminDto, LoginAdminDto } from './dto';
 import { AdminService } from './admin.service';
+import { RegisterJuniorDto } from '../junior/dto';
+import { Admin } from './admin.decorator';
 
 @Controller('admin')
 export class AdminController {
@@ -10,7 +12,7 @@ export class AdminController {
   ) { }
 
   @UsePipes(new ValidationPipe())
-  @Post('register')
+  @Post('register/admin')
   async create(@Body() userData: RegisterAdminDto) {
     return this.adminService.register(userData);
   }
@@ -21,17 +23,11 @@ export class AdminController {
     return this.adminService.login(userData);
   }
 
-  /** TEST CODE STARTS */
-  @Get('t1')
-  async getAll() {
-    return this.adminService.getAll1();
-  }
-
+  @UsePipes(new ValidationPipe())
   @UseGuards(AuthGuard('jwt'))
-  @Get('t2')
-  async getAll2() {
-    return this.adminService.getAll2();
+  @Post('register/junior')
+  async registerJunior(@Admin() payload: any, @Body() userData: RegisterJuniorDto) {
+    await this.adminService.verifyIsAdmin(payload.user);
+    return await this.adminService.registerJunior(userData);
   }
-
-  // TEST CODE ENDS
 }

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -27,6 +27,7 @@ export class AdminController {
   @UseGuards(AuthGuard('jwt'))
   @Post('register/junior')
   async registerJunior(@Admin() payload: any, @Body() userData: RegisterJuniorDto) {
+    // TODO: replace with authguard
     await this.adminService.verifyIsAdmin(payload.user);
     return await this.adminService.registerJunior(userData);
   }

--- a/backend/src/admin/admin.decorator.ts
+++ b/backend/src/admin/admin.decorator.ts
@@ -1,0 +1,3 @@
+import { createParamDecorator } from '@nestjs/common';
+
+export const Admin = createParamDecorator((data, req) => req.user);

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -12,6 +12,7 @@ import { JwtStrategy } from '../authentication/jwt.strategy';
 import { getTestDB } from '../../test/testdb';
 import { AdminModule } from './admin.module';
 import { AppModule } from '../app.module';
+import { JuniorModule } from '../junior/junior.module';
 
 describe('AdminService', () => {
   let module: TestingModule;
@@ -25,7 +26,7 @@ describe('AdminService', () => {
   beforeAll(async () => {
     connection = await getTestDB();
     module = await Test.createTestingModule({
-      imports: [AuthenticationModule, AdminModule, AppModule, JwtModule.register({
+      imports: [AuthenticationModule, AdminModule, AppModule, JuniorModule, JwtModule.register({
         secret: jwt.secret,
         signOptions: { expiresIn: jwt.expiry },
       })],

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -20,7 +20,7 @@ export class AdminService {
     login = async (loginData: LoginAdminDto) => this.authenticationService.loginAdmin(loginData);
     registerJunior = async (registrationData: RegisterJuniorDto) => this.authenticationService.registerJunior(registrationData);
 
-    // This will be handed to a guard once a clear workflow is provided for admin login.
+    // TODO:  This will be handed to a guard once a clear workflow is provided for admin login.
     verifyIsAdmin = async (email: string) => { if (!(await this.getUser(email))) { throw new UnauthorizedException(content.NotAnAdmin); } };
 
     async getUser(email: string): Promise<Admin> {

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Admin } from './admin.entity';
 import { AuthenticationService } from '../authentication/authentication.service';
 import { RegisterAdminDto, LoginAdminDto } from './dto';
+import { RegisterJuniorDto } from '../junior/dto';
+import * as content from '../content.json';
 
 @Injectable()
 export class AdminService {
@@ -16,6 +18,10 @@ export class AdminService {
 
     register = async (registrationData: RegisterAdminDto) => this.authenticationService.registerAdmin(registrationData);
     login = async (loginData: LoginAdminDto) => this.authenticationService.loginAdmin(loginData);
+    registerJunior = async (registrationData: RegisterJuniorDto) => this.authenticationService.registerJunior(registrationData);
+
+    // This will be handed to a guard once a clear workflow is provided for admin login.
+    verifyIsAdmin = async (email: string) => { if (!(await this.getUser(email))) { throw new UnauthorizedException(content.NotAnAdmin); } };
 
     async getUser(email: string): Promise<Admin> {
         return await this.adminRepo.findOne({ email: email.toLowerCase() });
@@ -25,9 +31,4 @@ export class AdminService {
         details.email = details.email.toLowerCase();
         await this.adminRepo.save(details);
     }
-
-    /** TEST CODE STARTS */
-    getAll1 = async () => (await this.adminRepo.find()).map(r => r.firstName);
-    getAll2 = async () => (await this.adminRepo.find()).map(r => `${r.firstName} ${r.lastName}`);
-    /** TEST CODE ENDS */
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { AdminController } from './admin/admin.controller';
 import { AdminModule } from './admin/admin.module';
 import { AuthenticationModule } from './authentication/authentication.module';
+import { JuniorModule } from './junior/junior.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { AuthenticationModule } from './authentication/authentication.module';
       synchronize: true,
     }),
     AdminModule,
+    JuniorModule,
     AuthenticationModule,
   ],
   controllers: [AppController, AdminController],

--- a/backend/src/authentication/authentication.module.ts
+++ b/backend/src/authentication/authentication.module.ts
@@ -5,13 +5,15 @@ import { AuthenticationService } from './authentication.service';
 import { AdminModule } from '../admin/admin.module';
 import { jwt } from './authentication.consts';
 import { JwtStrategy } from './jwt.strategy';
+import { JuniorService } from '../junior/junior.service';
+import { JuniorModule } from '../junior/junior.module';
 
 @Module({
   imports: [forwardRef(() => AdminModule), PassportModule,
   JwtModule.register({
     secret: jwt.secret,
     signOptions: { expiresIn: jwt.expiry },
-  })],
+  }), JuniorModule],
   providers: [AuthenticationService, JwtStrategy],
   exports: [AuthenticationService],
 })

--- a/backend/src/authentication/authentication.service.spec.ts
+++ b/backend/src/authentication/authentication.service.spec.ts
@@ -14,38 +14,50 @@ import { AdminModule } from '../admin/admin.module';
 import { AppModule } from '../app.module';
 import { RegisterAdminDto, LoginAdminDto } from '../admin/dto';
 import { ConflictException, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Junior } from '../junior/junior.entity';
+import { JuniorService } from '../junior/junior.service';
+import { JuniorModule } from '../junior/junior.module';
+import { RegisterJuniorDto } from 'src/junior/dto';
 
 describe('AuthenticationService', () => {
   let module: TestingModule;
   let connection: Connection;
   let service: AuthenticationService;
   let adminService: AdminService;
+  let juniorService: JuniorService;
 
-  const testRegister = {
+  const testRegisterAdmin = {
     email: 'Authentication@service.test', firstName: 'Auth',
     lastName: 'Tication', password: 'Hush',
   } as RegisterAdminDto;
-  const testLogin = {
-    email: testRegister.email, password: testRegister.password,
+  const testLoginAdmin = {
+    email: testRegisterAdmin.email, password: testRegisterAdmin.password,
   } as LoginAdminDto;
+  const testRegisterYouth = {
+    phoneNumber: '+4407805160073', firstName: 'Auth jr', lastName: 'Senior',
+  } as RegisterJuniorDto;
 
   beforeAll(async () => {
     connection = await getTestDB();
     module = await Test.createTestingModule({
-      imports: [AuthenticationModule, AdminModule, AppModule, JwtModule.register({
+      imports: [AuthenticationModule, AdminModule, AppModule, JuniorModule, JwtModule.register({
         secret: jwt.secret,
         signOptions: { expiresIn: jwt.expiry },
       })],
-      providers: [AdminService, AuthenticationService, {
+      providers: [AdminService, AuthenticationService, JuniorService, {
         provide: getRepositoryToken(Admin),
         useFactory: repositoryMockFactory,
-      }, JwtStrategy],
+      }, {
+          provide: getRepositoryToken(Junior),
+          useFactory: repositoryMockFactory,
+        }, JwtStrategy],
     }).overrideProvider(Connection)
       .useValue(connection)
       .compile();
 
     service = module.get<AuthenticationService>(AuthenticationService);
     adminService = module.get<AdminService>(AdminService);
+    juniorService = module.get<JuniorService>(JuniorService);
   });
 
   afterAll(async () => {
@@ -59,21 +71,21 @@ describe('AuthenticationService', () => {
 
   describe('Register admin', () => {
     it('should state that the registration is succesful', async () => {
-      expect(await service.registerAdmin(testRegister)).toBe(`${testRegister.email} luotu.`);
+      expect(await service.registerAdmin(testRegisterAdmin)).toBe(`${testRegisterAdmin.email} luotu.`);
     }),
       it('should add the user to the database following a succesful registration', async () => {
-        const response = await adminService.getUser(testRegister.email);
-        expect(response.email === testRegister.email.toLowerCase() &&
-          response.firstName === testRegister.firstName &&
-          response.lastName === testRegister.lastName).toBeTruthy();
+        const response = await adminService.getUser(testRegisterAdmin.email);
+        expect(response.email === testRegisterAdmin.email.toLowerCase() &&
+          response.firstName === testRegisterAdmin.firstName &&
+          response.lastName === testRegisterAdmin.lastName).toBeTruthy();
       }),
       it('should store passwords in a non-plaintext manner', async () => {
-        expect((await adminService.getUser(testRegister.email)).password).not.toEqual(testRegister.password);
+        expect((await adminService.getUser(testRegisterAdmin.email)).password).not.toEqual(testRegisterAdmin.password);
       }),
       it('should thrown a Conflict if the username already exists', async () => {
         const error = new ConflictException();
         try {
-          await service.registerAdmin(testRegister);
+          await service.registerAdmin(testRegisterAdmin);
           fail();
         } catch (e) {
           expect(e.response === error.getResponse());
@@ -83,12 +95,12 @@ describe('AuthenticationService', () => {
 
   describe('Login admin', () => {
     it('should return a access token token if login is succseful', async () => {
-      expect((await service.loginAdmin(testLogin)).access_token).toBeDefined();
+      expect((await service.loginAdmin(testLoginAdmin)).access_token).toBeDefined();
     }),
       it('should throw a Bad Request if the user does not exist', async () => {
         const error = new BadRequestException();
         try {
-          const testData = { email: 'email@e.mail', password: testLogin.password } as LoginAdminDto;
+          const testData = { email: 'email@e.mail', password: testLoginAdmin.password } as LoginAdminDto;
           await service.loginAdmin(testData);
           fail();
         } catch (e) {
@@ -98,8 +110,29 @@ describe('AuthenticationService', () => {
       it('should throw a Unauthorized if the password is incorrect', async () => {
         const error = new UnauthorizedException();
         try {
-          const testData = { email: testLogin.email, password: 'doubleHush' } as LoginAdminDto;
+          const testData = { email: testLoginAdmin.email, password: 'doubleHush' } as LoginAdminDto;
           await service.loginAdmin(testData);
+          fail();
+        } catch (e) {
+          expect(e.response === error.getResponse());
+        }
+      });
+  });
+
+  describe('Register Youth', () => {
+    it('should return a value (currently pin whilst waiting for further workflow)', async () => {
+      expect(await service.registerJunior(testRegisterYouth)).toBeDefined();
+    }),
+      it('should add the user to the database following a succesful registration', async () => {
+        const response = await juniorService.getUser(testRegisterYouth.phoneNumber);
+        expect(response.phoneNumber === testRegisterYouth.phoneNumber.toLowerCase() &&
+          response.firstName === testRegisterYouth.firstName &&
+          response.lastName === testRegisterYouth.lastName).toBeTruthy();
+      }),
+      it('should thrown a Conflict if the phone number already exists', async () => {
+        const error = new ConflictException();
+        try {
+          await service.registerJunior(testRegisterYouth);
           fail();
         } catch (e) {
           expect(e.response === error.getResponse());

--- a/backend/src/authentication/authentication.service.ts
+++ b/backend/src/authentication/authentication.service.ts
@@ -31,12 +31,13 @@ export class AuthenticationService {
     }
 
     /**
+    TODO: 
       Currently this returns the pin as we need pass that back to frontend.
       Will be corrected when relevant workflow is introduced.
      */
     async registerJunior(registrationData: RegisterJuniorDto): Promise<string> {
         const userExists = await this.juniorService.getUser(registrationData.phoneNumber);
-        if (userExists) { throw new ConflictException(content.AdminAlreadyExists); }
+        if (userExists) { throw new ConflictException(content.JuniorAlreadyExists); }
         const pin = this.juniorService.generatePin();
         const hashedPassword = await hash(pin, saltRounds);
         const junior = {

--- a/backend/src/authentication/authentication.service.ts
+++ b/backend/src/authentication/authentication.service.ts
@@ -6,12 +6,16 @@ import { Admin } from '../admin/admin.entity';
 import { AdminService } from '../admin/admin.service';
 import { RegisterAdminDto, LoginAdminDto } from '../admin/dto';
 import * as content from '../content.json';
+import { RegisterJuniorDto } from '../junior/dto';
+import { JuniorService } from '../junior/junior.service';
+import { Junior } from '../junior/junior.entity';
 
 @Injectable()
 export class AuthenticationService {
     constructor(
         @Inject(forwardRef(() => AdminService))
         private readonly adminService: AdminService,
+        private readonly juniorService: JuniorService,
         private readonly jwtService: JwtService) { }
 
     async registerAdmin(registrationData: RegisterAdminDto): Promise<any> {
@@ -26,6 +30,24 @@ export class AuthenticationService {
         return `${registrationData.email} ${content.Created}`;
     }
 
+    /**
+      Currently this returns the pin as we need pass that back to frontend.
+      Will be corrected when relevant workflow is introduced.
+     */
+    async registerJunior(registrationData: RegisterJuniorDto): Promise<string> {
+        const userExists = await this.juniorService.getUser(registrationData.phoneNumber);
+        if (userExists) { throw new ConflictException(content.AdminAlreadyExists); }
+        const pin = this.juniorService.generatePin();
+        const hashedPassword = await hash(pin, saltRounds);
+        const junior = {
+            firstName: registrationData.firstName, lastName: registrationData.lastName,
+            phoneNumber: registrationData.phoneNumber, pin: hashedPassword,
+        } as Junior;
+        await this.juniorService.createUser(junior);
+        //return `${registrationData.phoneNumber} ${content.Created} (PIN:${pin})`;
+        return pin;
+    }
+
     async loginAdmin(loginData: LoginAdminDto): Promise<any> {
         const user = await this.adminService.getUser(loginData.email);
         if (!user) { throw new BadRequestException(content.UserNotFound); }
@@ -33,4 +55,5 @@ export class AuthenticationService {
         if (!passwordMatches) { throw new UnauthorizedException(content.FailedLogin); }
         return { access_token: this.jwtService.sign({ user: user.email, sub: user.id }) };
     }
+
 }

--- a/backend/src/content.json
+++ b/backend/src/content.json
@@ -1,7 +1,9 @@
 {
     "AdminAlreadyExists": "An account for that email already exists.",
+    "NotAnAdmin": "You must be a youth worker to carry out this request.",
     "Created": "luotu.",
     "DataIncorrect": "The data provided is either incorrect or missing.",
     "FailedLogin": "Login failed.",
+    "JuniorAlreadyExists": "An account for that phone number already exists.",
     "UserNotFound": "User not found."
 }

--- a/backend/src/junior/dto/index.ts
+++ b/backend/src/junior/dto/index.ts
@@ -1,0 +1,1 @@
+export { RegisterJuniorDto } from './register.dto';

--- a/backend/src/junior/dto/register.dto.ts
+++ b/backend/src/junior/dto/register.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsPhoneNumber } from 'class-validator';
+
+export class RegisterJuniorDto {
+
+    @IsPhoneNumber(null)
+    @IsNotEmpty()
+    readonly phoneNumber: string;
+
+    @IsNotEmpty()
+    readonly firstName: string;
+
+    @IsNotEmpty()
+    readonly lastName: string;
+}

--- a/backend/src/junior/junior.entity.ts
+++ b/backend/src/junior/junior.entity.ts
@@ -15,6 +15,7 @@ export class Junior {
     @Column()
     pin: string;
 
+    // Todo: change to FI if needed depedant on SMS provider.
     @IsPhoneNumber(null)
     @Column({ unique: true })
     phoneNumber: string;

--- a/backend/src/junior/junior.entity.ts
+++ b/backend/src/junior/junior.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { IsPhoneNumber } from 'class-validator';
+
+@Entity()
+export class Junior {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    firstName: string;
+
+    @Column()
+    lastName: string;
+
+    @Column()
+    pin: string;
+
+    @IsPhoneNumber(null)
+    @Column({ unique: true })
+    phoneNumber: string;
+}

--- a/backend/src/junior/junior.module.ts
+++ b/backend/src/junior/junior.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { JuniorService } from './junior.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Junior } from './junior.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Junior])],
+  providers: [JuniorService],
+  exports: [JuniorService],
+})
+export class JuniorModule { }

--- a/backend/src/junior/junior.service.spec.ts
+++ b/backend/src/junior/junior.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JuniorService } from './junior.service';
+import { JuniorModule } from './junior.module';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Junior } from './junior.entity';
+import { repositoryMockFactory } from '../../test/Mock';
+import { AppModule } from '../app.module';
+import { Connection } from 'typeorm';
+import { getTestDB } from '../../test/testdb';
+
+describe('JuniorService', () => {
+  let module: TestingModule;
+  let service: JuniorService;
+  let connection: Connection;
+
+  beforeAll(async () => {
+    connection = await getTestDB();
+    module = await Test.createTestingModule({
+      imports: [JuniorModule, AppModule],
+      providers: [JuniorService, {
+        provide: getRepositoryToken(Junior),
+        useFactory: repositoryMockFactory,
+      }],
+    }).overrideProvider(Connection)
+      .useValue(connection)
+      .compile();
+
+    service = module.get<JuniorService>(JuniorService);
+  });
+
+  afterAll(async () => {
+    await module.close();
+    await connection.close();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { Junior } from './junior.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class JuniorService {
+
+    constructor(
+        @InjectRepository(Junior)
+        private readonly juniorRepo: Repository<Junior>,
+    ) { }
+
+    async getUser(phoneNumber: string): Promise<Junior> {
+        return await this.juniorRepo.findOne({ phoneNumber });
+    }
+
+    async createUser(details: Junior) {
+        await this.juniorRepo.save(details);
+    }
+
+    // This will be moved to its own service when the pin workflow is produced.
+    generatePin(): string {
+        return (Math.floor(1000 + Math.random() * 9000)).toString();
+    }
+}

--- a/backend/test/Mock.ts
+++ b/backend/test/Mock.ts
@@ -7,5 +7,5 @@ export type MockType<T> = {
 // @ts-ignore
 export const repositoryMockFactory: () => MockType<Repository<any>> = jest.fn(() => ({
     findOne: jest.fn(entity => entity),
-    find: jest.fn(entity => entity)
+    find: jest.fn(entity => entity),
 }));

--- a/backend/test/admin.e2e-spec.ts
+++ b/backend/test/admin.e2e-spec.ts
@@ -2,20 +2,27 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 import { Connection } from 'typeorm';
-import { RegisterAdminDto, LoginAdminDto } from 'src/admin/dto';
+import { RegisterAdminDto, LoginAdminDto } from '../src/admin/dto';
 import { getTestDB } from './testdb';
+import { RegisterJuniorDto } from '../src/junior/dto';
 
 describe('AdminController (e2e)', () => {
     let app;
     let connection: Connection;
+    let token: string;
 
-    const testRegister = {
+    const testAdminRegister = {
         email: 'Testy.McTestFace@gofore.com', password: 'Password',
         firstName: 'Testy', lastName: 'McTestFace',
     } as RegisterAdminDto;
 
-    const testLogin = {
-        email: testRegister.email, password: testRegister.password,
+    const testJuniorRegister = {
+        phoneNumber: '+441234567896',
+        firstName: 'Testy jr', lastName: 'e2e',
+    } as RegisterJuniorDto;
+
+    const testAdminLogin = {
+        email: testAdminRegister.email, password: testAdminRegister.password,
     } as LoginAdminDto;
 
     beforeAll(async () => {
@@ -37,24 +44,63 @@ describe('AdminController (e2e)', () => {
         await app.close();
     });
 
-    describe('/admin/register', () => {
+    describe('/admin/register/admin', () => {
         it('returns a Created if a new user is created', async () => {
             return request(app.getHttpServer())
-                .post('/admin/register')
-                .send(testRegister)
+                .post('/admin/register/admin')
+                .send(testAdminRegister)
                 .expect(201);
         }),
             it('returns a Conflict if the user already exists', async () => {
                 return request(app.getHttpServer())
-                    .post('/admin/register')
-                    .send(testRegister)
+                    .post('/admin/register/admin')
+                    .send(testAdminRegister)
                     .expect(409);
             }),
             it('returns an Bad Request if invalid data is entered', () => {
                 return request(app.getHttpServer())
-                    .post('/admin/register')
-                    .send(testLogin)
+                    .post('/admin/register/admin')
+                    .send(testAdminLogin)
                     .expect(400);
+            });
+    });
+
+    describe('/admin/register/junior', () => {
+        beforeAll(async () => {
+            token = (await request(app.getHttpServer())
+                .post('/admin/login')
+                .send(testAdminLogin)).body.access_token;
+        }),
+            it('returns a pin (temporary) if a new user is created', async () => {
+                return request(app.getHttpServer())
+                    .post('/admin/register/junior')
+                    .set('Authorization', `Bearer ${token}`)
+                    .set('Accept', 'application/json')
+                    .send(testJuniorRegister)
+                    .expect(201);
+            }),
+            it('returns a Conflict if the user already exists', async () => {
+                return request(app.getHttpServer())
+                    .post('/admin/register/junior')
+                    .set('Authorization', `Bearer ${token}`)
+                    .set('Accept', 'application/json')
+                    .send(testJuniorRegister)
+                    .expect(409);
+            }),
+            it('returns an Bad Request if invalid data is entered', () => {
+                let testData = { firstName: 'Bob', lastName: 'Bobby' };
+                return request(app.getHttpServer())
+                    .post('/admin/register/junior')
+                    .set('Authorization', `Bearer ${token}`)
+                    .set('Accept', 'application/json')
+                    .send(testData)
+                    .expect(400);
+            }),
+            it('returns an Unauthorized if no JWT token is provided', () => {
+                return request(app.getHttpServer())
+                    .post('/admin/register/junior')
+                    .send(testJuniorRegister)
+                    .expect(401);
             });
     });
 
@@ -62,28 +108,28 @@ describe('AdminController (e2e)', () => {
         it('returns a JWT token on a succesful login', () => {
             return request(app.getHttpServer())
                 .post('/admin/login')
-                .send(testLogin)
+                .send(testAdminLogin)
                 .expect('Content-Type', /json/)
                 .expect(201).then(response => {
                     expect(response !== null);
                 });
         }),
             it('returns a Bad Request if the email does not exist', () => {
-                const testData = { email: 'boaty.mcboatface@gofore.com', password: testLogin.password } as LoginAdminDto;
+                const testData = { email: 'boaty.mcboatface@gofore.com', password: testAdminLogin.password } as LoginAdminDto;
                 return request(app.getHttpServer())
                     .post('/admin/login')
                     .send(testData)
                     .expect(400);
             }),
             it('returns Unauthorized if an invalid password is provided', () => {
-                const testData = { email: testLogin.email, password: 'wordswordswords' } as LoginAdminDto;
+                const testData = { email: testAdminLogin.email, password: 'wordswordswords' } as LoginAdminDto;
                 return request(app.getHttpServer())
                     .post('/admin/login')
                     .send(testData)
                     .expect(401);
             }),
             it('returns a Bad Request if invalid data is entered', () => {
-                const testData = { email: testLogin.email };
+                const testData = { email: testAdminLogin.email };
                 return request(app.getHttpServer())
                     .post('/admin/login')
                     .send(testData)


### PR DESCRIPTION
Please note 2 points within this build.

1. We are currently using a method to determine which JWT is admin, which is not. This is typically handled using an auth guard; however, the implementation of such a guard is best left until more information is created regarding the user.
2. Currently registering a user returns the pin that was created. This was produced as we currently have no method of passing the PIN to the user. Upon SMS implementation this will be resolved.