### PR TITLE
Prevent duplicate checkin

### DIFF
--- a/admin-frontend/src/components/checkIn.js
+++ b/admin-frontend/src/components/checkIn.js
@@ -75,9 +75,15 @@ const CheckInView = (props) => {
         .then(response => {
           const { showNotification } = props;
           if (response.statusCode < 200 || response.statusCode >= 300) {
-            showNotification('Jokin meni pieleen! Kokeile uudestaan.', 'warning')
+              showNotification('Jokin meni pieleen! Kokeile uudestaan.', 'warning')
           } else {
-            handleCheckInSuccess();
+            if (response.success === false) {
+              showNotification('Jokin meni pieleen. Yrititkö kirjautua samalla QR-koodilla useamman kerran?', 'warning')
+              setLoading(false);
+              setShowQRCode(true);
+            } else {
+              handleCheckInSuccess();
+            }
           }
         });
     }

--- a/backend/src/club/club.service.spec.ts
+++ b/backend/src/club/club.service.spec.ts
@@ -97,10 +97,25 @@ describe('ClubService', () => {
     });
   });
 
+  // If you change junior used in this test, do same to test below, they are chained
   describe('CheckInJunior', () => {
     it('Should return true when successful', async () => {
       const result = await service.checkInJunior({ juniorId: testJuniors[0].id, clubId: testClub.id });
       expect(result).toBeTruthy();
+    });
+  });
+
+  describe('CheckInJuniorDuplicate', () => {
+    it('Should return true when trying to check same junior again', async () => {
+      const result = await service.checkIfAlreadyCheckedIn(testJuniors[0].id, testClub.id);
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('CheckInJuniorDuplicate', () => {
+    it('Should return false when trying to check new junior', async () => {
+      const result = await service.checkIfAlreadyCheckedIn(testJuniors[1].id, testClub.id);
+      expect(result).toBeFalsy();
     });
   });
 

--- a/backend/src/club/club.service.ts
+++ b/backend/src/club/club.service.ts
@@ -8,6 +8,7 @@ import * as content from '../content.json';
 import { CheckInDto, LogBookDto } from './dto';
 import * as ageRanges from './logbookAgeRanges.json';
 import * as clubs from './youthClubs.json';
+import { datesDifferLessThan } from '../utils/helpers';
 
 @Injectable()
 export class ClubService {
@@ -49,6 +50,17 @@ export class ClubService {
 
     async getClubs(): Promise<ClubViewModel[]> {
         return (await this.clubRepo.find()).map(club => new ClubViewModel(club));
+    }
+
+    async checkIfAlreadyCheckedIn(juniorId: string, clubId: string): Promise<boolean> {
+        const checkIns = await this.getCheckinsForClub(clubId);
+        let duplicateCheckIn = false;
+        await checkIns.forEach((checkIn) => {
+            if (checkIn.junior.id === juniorId && datesDifferLessThan(new Date(), new Date(checkIn.checkInTime), 2)) {
+                duplicateCheckIn = true;
+            }
+        });
+        return duplicateCheckIn;
     }
 
     async getCheckinsForClub(clubId: string): Promise<CheckIn[]> {

--- a/backend/src/utils/helpers.spec.ts
+++ b/backend/src/utils/helpers.spec.ts
@@ -1,0 +1,18 @@
+import { datesDifferLessThan } from './helpers';
+
+describe('Helpers', () => {
+    describe('dateDiffersLessThan', () => {
+        it('should return false when dates differ more than given amount`', () => {
+            const date1 = new Date();
+            const date2 = new Date();
+            date2.setHours(date1.getHours() + 3);
+            expect(datesDifferLessThan(date1, date2, 2)).toBeFalsy();
+        });
+        it('should return true when dates differ less than given amount`', () => {
+            const date1 = new Date();
+            const date2 = new Date();
+            date2.setHours(date1.getHours() + 1);
+            expect(datesDifferLessThan(date1, date2, 2)).toBeTruthy();
+        });
+    });
+});

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,0 +1,8 @@
+export const datesMatchOnHourlyLevel = (d1: Date, d2: Date): boolean => {
+    return (
+        d1.getFullYear() === d2.getFullYear() &&
+        d1.getMonth() === d2.getMonth() &&
+        d1.getDay() === d2.getDay() &&
+        d1.getHours() === d2.getHours()
+    );
+};

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,8 +1,8 @@
-export const datesMatchOnHourlyLevel = (d1: Date, d2: Date): boolean => {
+export const datesDifferLessThan = (d1: Date, d2: Date, maxDiff: number): boolean => {
     return (
         d1.getFullYear() === d2.getFullYear() &&
         d1.getMonth() === d2.getMonth() &&
         d1.getDay() === d2.getDay() &&
-        d1.getHours() === d2.getHours()
+        Math.abs(d1.getHours() - d2.getHours()) < maxDiff
     );
 };


### PR DESCRIPTION
Added duplicate checkin check. Works by comparing that no checkin has happened in last 2 hours with same QR-code. 