### PR TITLE
fix: phone number validation bug

### DIFF
--- a/backend/src/content.json
+++ b/backend/src/content.json
@@ -17,7 +17,6 @@
   "JuniorAlreadyExists": "Käyttäjätili on jo luotu tällä puhelinnumerolla.",
   "LockedOut": "Liian monta väärää yritystä.",
   "Reset": "Palautuslinkki lähetetty.",
-  "ValueIsNotPhoneNumber": "Annettu arvo ei ole puhelinnumero. Saatu arvo: $value.",
   "Updated": "Päivitetty.",
   "UserNotFound": "Käyttäjää ei löydy.",
   "MessengerServiceNotAvailable": "Tekstiviestipalvelu on tilapäisesti pois käytöstä.",
@@ -27,5 +26,7 @@
   "Routes": {
     "api": "api",
     "admin": "nuorisotyontekijat"
-  }
+  },
+  "PhoneNumberNotValid":"Puhelinnumero on virheellinen",
+  "ParentsPhoneNumberNotValid": "Huoltajan puhelinnumero on virheellinen"
 }

--- a/backend/src/junior/dto/edit.dto.ts
+++ b/backend/src/junior/dto/edit.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsPhoneNumber, Length, IsDateString, IsDate } from 'class-validator';
+import { IsNotEmpty, Length, IsDateString, IsDate } from 'class-validator';
 import * as content from '../../content.json';
 
 export class EditJuniorDto {
@@ -6,7 +6,6 @@ export class EditJuniorDto {
     @IsNotEmpty()
     readonly id: string;
 
-    @IsPhoneNumber('FI', { message: content.ValueIsNotPhoneNumber })
     phoneNumber: string;
 
     firstName: string;
@@ -19,7 +18,6 @@ export class EditJuniorDto {
 
     parentsName: string;
 
-    @IsPhoneNumber('FI', { message: content.ValueIsNotPhoneNumber })
     parentsPhoneNumber: string;
 
     @Length(1, 1)

--- a/backend/src/junior/dto/register.dto.ts
+++ b/backend/src/junior/dto/register.dto.ts
@@ -1,9 +1,8 @@
-import { IsNotEmpty, IsPhoneNumber, Length, IsDateString } from 'class-validator';
+import { IsNotEmpty, Length, IsDateString } from 'class-validator';
 import * as content from '../../content.json';
 
 export class RegisterJuniorDto {
 
-    @IsPhoneNumber('FI', { message: content.ValueIsNotPhoneNumber })
     @IsNotEmpty()
     readonly phoneNumber: string;
 
@@ -21,7 +20,6 @@ export class RegisterJuniorDto {
     @IsNotEmpty()
     readonly parentsName: string;
 
-    @IsPhoneNumber('FI', { message: content.ValueIsNotPhoneNumber })
     @IsNotEmpty()
     readonly parentsPhoneNumber: string;
 

--- a/backend/src/junior/dto/reset.dto.ts
+++ b/backend/src/junior/dto/reset.dto.ts
@@ -1,9 +1,8 @@
-import { IsNotEmpty, IsPhoneNumber } from 'class-validator';
+import { IsNotEmpty } from 'class-validator';
 import * as content from '../../content.json';
 
 export class ResetJuniorDto {
 
-    @IsPhoneNumber('FI', { message: content.ValueIsNotPhoneNumber })
     @IsNotEmpty()
     readonly phoneNumber: string;
 

--- a/backend/src/junior/entities/junior.entity.ts
+++ b/backend/src/junior/entities/junior.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
-import { IsPhoneNumber, Length } from 'class-validator';
+import { Length } from 'class-validator';
 import { makePhoneNumberInternational, lowercase, trimString } from '../../common/transformers';
 import { CheckIn } from '../../club/entities';
 import { ConfigHelper } from '../../configHandler';
@@ -18,7 +18,6 @@ export class Junior {
     @Column({ default: '', transformer: trimString })
     nickName: string;
 
-    @IsPhoneNumber('FI')
     @Column({ unique: true, transformer: makePhoneNumberInternational })
     phoneNumber: string;
 
@@ -28,7 +27,6 @@ export class Junior {
     @Column()
     parentsName: string;
 
-    @IsPhoneNumber('FI')
     @Column({ transformer: makePhoneNumberInternational })
     parentsPhoneNumber: string;
 

--- a/backend/src/junior/junior.controller.ts
+++ b/backend/src/junior/junior.controller.ts
@@ -20,6 +20,8 @@ import { Challenge } from './entities';
 import { ConfigHelper } from '../configHandler';
 import * as content from '../content.json';
 import { ListControlDto } from '../common/dto';
+import { PhoneNumberValidationPipe } from './pipes/phoneNumberValidation.pipe';
+import { ResetPhoneNumberValidationPipe } from './pipes/resetPhoneNumberValidation.pipe';
 
 @Controller(`${content.Routes.api}/junior`)
 export class JuniorController {
@@ -33,7 +35,7 @@ export class JuniorController {
     @UseGuards(AuthGuard('jwt'), RolesGuard)
     @AllowedRoles(Roles.ADMIN)
     @Post('register')
-    async registerJunior(@Body() userData: RegisterJuniorDto): Promise<Message> {
+    async registerJunior(@Body(PhoneNumberValidationPipe) userData: RegisterJuniorDto): Promise<Message> {
         return new Message(await this.juniorService.registerJunior(userData));
     }
 
@@ -60,7 +62,7 @@ export class JuniorController {
 
     @UsePipes(new ValidationPipe({ transform: true }))
     @Post('reset')
-    async resetLogin(@Body() userData: ResetJuniorDto): Promise<Message> {
+    async resetLogin(@Body(ResetPhoneNumberValidationPipe) userData: ResetJuniorDto): Promise<Message> {
         return new Message(await this.juniorService.resetLogin(userData.phoneNumber));
     }
 
@@ -69,7 +71,7 @@ export class JuniorController {
     @AllowedRoles(Roles.ADMIN)
     @UseInterceptors(JuniorEditInterceptor)
     @Post('edit')
-    async edit(@Body() userData: EditJuniorDto): Promise<Message> {
+    async edit(@Body(PhoneNumberValidationPipe) userData: EditJuniorDto): Promise<Message> {
         return new Message(await this.juniorService.editJunior(userData));
     }
 

--- a/backend/src/junior/pipes/phoneNumberValidation.pipe.ts
+++ b/backend/src/junior/pipes/phoneNumberValidation.pipe.ts
@@ -1,0 +1,26 @@
+import { PipeTransform, BadRequestException } from "@nestjs/common";
+import * as content from '../../content.json';
+
+// Custom pipe for handling "phoneNumber" and "parentsPhoneNumber" validation while adding/editing junior details
+export class PhoneNumberValidationPipe implements PipeTransform {
+  readonly allowedPhoneNumber = /(^(\+358|0|358)\d{9}$)/;
+
+  transform(value: any) {
+    const { phoneNumber, parentsPhoneNumber } = value;
+
+    if(!this.isPhoneNumberValid(phoneNumber)) {
+      throw new BadRequestException(content.PhoneNumberNotValid);
+    }
+
+    else if(!this.isPhoneNumberValid(parentsPhoneNumber)) {
+      throw new BadRequestException(content.ParentsPhoneNumberNotValid);
+    }
+
+    return value;
+  }
+
+  private isPhoneNumberValid(phoneNumber: any) {
+    const isValid = this.allowedPhoneNumber.test(phoneNumber);
+    return isValid;
+  }
+}

--- a/backend/src/junior/pipes/resetPhoneNumberValidation.pipe.ts
+++ b/backend/src/junior/pipes/resetPhoneNumberValidation.pipe.ts
@@ -1,0 +1,22 @@
+import { PipeTransform, BadRequestException } from "@nestjs/common";
+import * as content from '../../content.json';
+
+// Custom pipe for handling "phoneNumber" validation while resending SMS
+export class ResetPhoneNumberValidationPipe implements PipeTransform {
+  readonly allowedPhoneNumber = /(^(\+358|0|358)\d{9}$)/;
+
+  transform(value: any) {
+    const { phoneNumber } = value;
+
+    if(!this.isPhoneNumberValid(phoneNumber)) {
+      throw new BadRequestException(content.PhoneNumberNotValid);
+    }
+
+    return value;
+  }
+
+  private isPhoneNumberValid(phoneNumber: any) {
+    const isValid = this.allowedPhoneNumber.test(phoneNumber);
+    return isValid;
+  }
+}

--- a/backend/task-definition.json
+++ b/backend/task-definition.json
@@ -35,6 +35,10 @@
         {
           "name": "RDS_HOSTNAME",
           "value":"vantaa-nuta-2020-2.cekah5govxhb.eu-west-1.rds.amazonaws.com"
+        },
+        {
+          "name": "FRONTEND",
+          "value":"http://youth-club-mobile-lb-74625212.eu-west-1.elb.amazonaws.com/"
         }
       ],
       "secrets": [


### PR DESCRIPTION
With this PR, a custom pipe for handling the `phoneNumber` and `parentsPhoneNumber` validation is implemented to:
* fix the bug _(in `class-validator` library)_ which caused the app to break while sending SMS & not allowing admins to edit junior details.

Also, updated `task-definition.json`  _(to add `FRONTEND` url)_