### PR TITLE
Transform phone input value into supported format

### DIFF
--- a/frontend/src/components/ParentRegistration/RegistrationView/Form.tsx
+++ b/frontend/src/components/ParentRegistration/RegistrationView/Form.tsx
@@ -36,7 +36,7 @@ const InnerForm = (props: FormikProps<FormValues>) => {
                         <Field name='juniorLastName' component={InputField} title='Sukunimi'/>
                         <Field name='juniorNickName' component={InputField} title='Kutsumanimi'/>
                         <Field name='juniorBirthday' component={InputField} title='Syntymäaika' placeholder='pp.kk.vvvv'/>
-                        <Field name='juniorPhoneNumber' component={InputField} title='Puhelinnumero'/>
+                        <Field name='juniorPhoneNumber' component={InputField} type='phone' title='Puhelinnumero'/>
                         <Field name='postCode' component={InputField} title='Postinumero'/>
                         <Field name='school' component={InputField} title='Koulun nimi'/>
                         <Field name='class' component={InputField} title='Luokka'/>
@@ -66,7 +66,7 @@ const InnerForm = (props: FormikProps<FormValues>) => {
                         <FieldTitle>Huoltajan tiedot</FieldTitle>
                         <Field disabled name='parentFirstName' component={InputField} title='Etunimi'/>
                         <Field disabled name='parentLastName' component={InputField} title='Sukunimi'/>
-                        <Field name='parentPhoneNumber' component={InputField} title='Puhelinnumero'/>
+                        <Field name='parentPhoneNumber' component={InputField} type='phone' title='Puhelinnumero'/>
                     </Fieldset>
 
                     <Fieldset>

--- a/frontend/src/components/ParentRegistration/RegistrationView/FormFields.tsx
+++ b/frontend/src/components/ParentRegistration/RegistrationView/FormFields.tsx
@@ -7,22 +7,31 @@ import { Label, Description, ErrorMessage, Input, Select, SelectOption, SelectLa
 interface InputProps {
     title: string,
     placeholder?: string,
-    description?: string
+    description?: string,
+    type?: string
 }
 
 export const InputField: React.FC<FieldProps & InputProps> = ({
     field,
     title,
     placeholder,
-    form: {touched, errors, handleBlur},
+    type,
+    form: {touched, errors, handleBlur, setFieldValue},
     ...props
 }) => {
+    const onBlur = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (type === 'phone') {
+            const val = e.target.value.replace(/[^\d+]/g, '');
+            setFieldValue(field.name, val);
+        }
+        handleBlur(e)
+    }
     const isTouched = get(touched, field.name);
     const error = get(errors, field.name);
     return (
         <div>
             <Label>{title}</Label>
-            <Input placeholder={placeholder} {...field} {...props} onBlur={handleBlur} />
+            <Input placeholder={placeholder} {...field} {...props} onBlur={onBlur} />
             {isTouched &&
             error && <ErrorMessage>{error}</ErrorMessage>}
         </div>
@@ -46,13 +55,13 @@ const RadioField: React.FC<RadioProps & FieldProps> = ({
   }) => {
     return (
         <SelectOption>
-            <Radio type="radio" id={data.value} 
-                name={field.name} 
-                value={data.value} 
-                checked={field.value === data.value} 
+            <Radio type="radio" id={data.value}
+                name={field.name}
+                value={data.value}
+                checked={field.value === data.value}
                 onChange={field.onChange}
                 {...props}
-                onBlur={field.onBlur} 
+                onBlur={field.onBlur}
                 />
             <SelectLabel htmlFor={data.value}>{data.label}</SelectLabel>
         </SelectOption>
@@ -72,7 +81,7 @@ export const SelectGroup: React.FC<GroupProps> = ({
     title,
     error,
     touched,
-    options, 
+    options,
     description
 }) => {
     const inputs = options.map(option => (


### PR DESCRIPTION
Formik doesn't support yup transformations, hence cleaning the input from extra characters like spaces/hyphens was done before validation.