### PR TITLE
quickfix to use internationally transformed phone value in sms service

### DIFF
--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -179,9 +179,11 @@ export class JuniorService {
             throw new BadRequestException(errors);
         }
         await this.juniorRepo.save(user);
+        //typeorm doesn't currently return transformed values on save, have to retrieve it again to get the phone number in a correct format
         if (prevStatus === 'pending' && details.status === 'accepted') {
-            const challenge = await this.setChallenge(user.phoneNumber);
-            const messageSent = await this.smsService.sendVerificationSMS({ name: user.firstName, phoneNumber: user.phoneNumber }, challenge);
+            const updatedJunior = await this.getJuniorByPhoneNumber(user.phoneNumber);
+            const challenge = await this.setChallenge(updatedJunior.phoneNumber);
+            const messageSent = await this.smsService.sendVerificationSMS({ name: updatedJunior.firstName, phoneNumber: updatedJunior.phoneNumber }, challenge);
             if (!messageSent) { throw new InternalServerErrorException(content.MessengerServiceNotAvailable); }
         }
         return `${details.phoneNumber} ${content.Updated}`;

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,1 @@
-REACT_APP_ENDPOINT=https://localhost/api
-REACT_APP_WEBSOCKET=http://localhost:3000/
+REACT_APP_ENDPOINT=http://localhost:3000/api


### PR DESCRIPTION
Currently typeORM doesn't return transformed values on save, hence the junior is re-retrieved to get up-to-date data.