### PR TITLE
Refresh a qr scanner page every 10 minutes

### DIFF
--- a/admin-frontend/src/components/checkIn/checkIn.js
+++ b/admin-frontend/src/components/checkIn/checkIn.js
@@ -61,7 +61,8 @@ const CheckInView = (props) => {
   },[])
   // reload the page in 10 minutes to fix qr reader stopping scanning after a period of time
   useEffect(() => {
-    setTimeout(() => window.location.reload(), 600000)
+    const timer = setTimeout(() => window.location.reload(), 600000);
+    return () => clearTimeout(timer);
   }, [])
 
   useEffect(() => {

--- a/admin-frontend/src/components/checkIn/checkIn.js
+++ b/admin-frontend/src/components/checkIn/checkIn.js
@@ -59,6 +59,10 @@ const CheckInView = (props) => {
     }
 
   },[])
+  // reload the page in 10 minutes to fix qr reader stopping scanning after a period of time
+  useEffect(() => {
+    setTimeout(() => window.location.reload(), 600000)
+  }, [])
 
   useEffect(() => {
     if(props.location.state !== undefined) {


### PR DESCRIPTION
QR reader starts to have problems with scanning after a certain amount of time, and requires a manual page refresh. Refreshing the page automatically should solve the problem