### PR TITLE
add new status, edit old status

### DIFF
--- a/admin-frontend/src/components/junior.js
+++ b/admin-frontend/src/components/junior.js
@@ -237,7 +237,7 @@ export const JuniorEdit = (props) => {
                 <BooleanInput label="Kuvauslupa" source="photoPermission" />
                 <SelectInput label="Kotisoitto" source="status" choices={statusChoices} validate={required()}/>
                 <FormDataConsumer>
-                 {({ formData, record }) => (formData.status === 'accepted' && record.status==='pending') &&
+                 {({ formData, record }) => (formData.status === 'accepted' && (record.status==='pending' || record.status === 'failedCall')) &&
                     <SMSwarning/>
                  }
              </FormDataConsumer>

--- a/admin-frontend/src/utils.js
+++ b/admin-frontend/src/utils.js
@@ -9,8 +9,10 @@ export const genderChoices = [
 ];
 
 export const statusChoices = [
-  { id: 'accepted', name: 'Tehty' },
-  { id: 'pending', name: 'Tekemättä' }
+  { id: 'accepted', name: 'Kotisoitto tehty' },
+  { id: 'pending', name: 'Kotisoitto tekemättä' },
+  { id: 'expired', name:  'Tunnus vanhentunut' },
+  { id: 'failedCall', name: 'Kotisoittoa yritetty' }
 ];
 
 export const token = 'admin-token';

--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -187,7 +187,7 @@ export class JuniorService {
         }
         await this.juniorRepo.save(user);
         //typeorm doesn't currently return transformed values on save, have to retrieve it again to get the phone number in a correct format
-        if (prevStatus === 'pending' && details.status === 'accepted') {
+        if ((prevStatus === 'pending' || prevStatus === 'failedCall') && details.status === 'accepted') {
             const updatedJunior = await this.getJuniorByPhoneNumber(user.phoneNumber);
             const challenge = await this.setChallenge(updatedJunior.phoneNumber);
             const messageSent = await this.smsService.sendVerificationSMS({ name: updatedJunior.firstName, phoneNumber: updatedJunior.phoneNumber }, challenge);


### PR DESCRIPTION
Since the status is not an enum or an entity but a string, no migration needed as logic compare the string itself always