### PR TITLE
add sms for new season changes, fix admin user role guard for season endpoints

### DIFF
--- a/backend/src/junior/dto/index.ts
+++ b/backend/src/junior/dto/index.ts
@@ -4,3 +4,4 @@ export { EditJuniorDto } from './edit.dto';
 export { ResetJuniorDto } from './reset.dto';
 export { GetJuniorDto } from './get.dto';
 export { ParentFormDto } from './parent.dto';
+export { SeasonExpiredDto } from './season-expired.dto'

--- a/backend/src/junior/dto/season-expired.dto.ts
+++ b/backend/src/junior/dto/season-expired.dto.ts
@@ -1,8 +1,9 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsDateString, IsNotEmpty } from 'class-validator';
 
 export class SeasonExpiredDto {
 
     @IsNotEmpty()
+    @IsDateString()
     readonly expireDate: string;
 
 }

--- a/backend/src/junior/dto/season-expired.dto.ts
+++ b/backend/src/junior/dto/season-expired.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class SeasonExpiredDto {
+
+    @IsNotEmpty()
+    readonly expireDate: string;
+
+}

--- a/backend/src/junior/junior.controller.ts
+++ b/backend/src/junior/junior.controller.ts
@@ -3,7 +3,7 @@ import {
     Get, Param, BadRequestException, Delete, Query, Res,
 } from '@nestjs/common';
 import { JuniorService } from './junior.service';
-import { LoginJuniorDto, RegisterJuniorDto, EditJuniorDto, ResetJuniorDto, ParentFormDto } from './dto';
+import { LoginJuniorDto, RegisterJuniorDto, EditJuniorDto, ResetJuniorDto, ParentFormDto, SeasonExpiredDto } from './dto';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthenticationService } from '../authentication/authentication.service';
 import { AllowedRoles } from '../roles/roles.decorator';
@@ -135,15 +135,15 @@ export class JuniorController {
 
     @UsePipes(new ValidationPipe({ transform: true }))
     @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @AllowedRoles(Roles.ADMIN)
+    @AllowedRoles(Roles.SUPERUSER)
     @Post('newSeason')
-    async createNewSeason() {
-        return new Message(await this.juniorService.createNewSeason());
+    async createNewSeason(@Body() expireDate: SeasonExpiredDto) {
+        return new Message(await this.juniorService.createNewSeason(expireDate));
     }
 
     @UsePipes(new ValidationPipe({ transform: true }))
     @UseGuards(AuthGuard('jwt'), RolesGuard)
-    @AllowedRoles(Roles.ADMIN)
+    @AllowedRoles(Roles.SUPERUSER)
     @Delete('newSeason/clearExpired')
     async deleteExpiredJuniors() {
         return new Message(await this.juniorService.deleteExpired());

--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -258,7 +258,9 @@ export class JuniorService {
             if (!messageSent) { smsFailure.push(junior.parentsPhoneNumber) }
         }))
 
-        return `New season created. ${result.affected} juniors expired. ${smsFailure.length} sms sent unsuccessful.`;
+        const failPhoneNumber: string = smsFailure.length > 0 ? `Fail numbers are: ${smsFailure.toString()}` : ''
+
+        return `New season created. ${result.affected} juniors expired. ${smsFailure.length} sms sent unsuccessful.` +  failPhoneNumber;
     }
 
     async deleteExpired(): Promise<string> {

--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -251,16 +251,17 @@ export class JuniorService {
 
         const listJunior = await this.juniorRepo.find();
 
-        let smsFailure: string[] = []
+        let smsFailureNumber: number = 0
 
         await Promise.all(listJunior.map(async (junior: Junior) => {
             const messageSent = await this.smsService.sendNewSeasonSMS({ name: `${junior.firstName} ${junior.lastName}`, phoneNumber: junior.parentsPhoneNumber }, expireDate.expireDate);
-            if (!messageSent) { smsFailure.push(junior.parentsPhoneNumber) }
+            if (!messageSent) {
+                smsFailureNumber++;
+                console.warn(`Failed to send SMS to ${junior.parentsPhoneNumber}`);
+            }
         }))
 
-        const failPhoneNumber: string = smsFailure.length > 0 ? `Fail numbers are: ${smsFailure.toString()}` : ''
-
-        return `New season created. ${result.affected} juniors expired. ${smsFailure.length} sms sent unsuccessful.` +  failPhoneNumber;
+        return `New season created. ${result.affected} juniors expired. ${smsFailureNumber} sms sent unsuccessful.`;
     }
 
     async deleteExpired(): Promise<string> {

--- a/backend/src/sms/sms.service.ts
+++ b/backend/src/sms/sms.service.ts
@@ -4,6 +4,7 @@ import { Challenge } from '../junior/entities';
 import { SMSConfig } from './smsConfigHandler';
 import * as content from '../content.json';
 import { ConfigHelper } from '../configHandler';
+import moment = require('moment');
 
 @Injectable()
 export class SmsService {
@@ -20,7 +21,7 @@ export class SmsService {
         const checkRegisterJuniorCalls = new Error().stack.split("at ")[2].includes("registerJunior");
 
         if (!settings) {
-            if(checkRegisterJuniorCalls) {
+            if (checkRegisterJuniorCalls) {
                 throw new InternalServerErrorException(content.SMSNotAvailableButUserCreated);
             }
             else {
@@ -86,10 +87,21 @@ export class SmsService {
     }
 
     private getExpiredMessage(recipientName: string, expiredDate: string): string {
-        return `Hei\n\nNuoren ${recipientName} Mobiilinutakortti odottaa uusimista kaudelle ${this.getSeasonPeriod()}. Alla olevasta linkistä pääset uusimaan nuoren hakemuksen ja päivittämään yhteystiedot. Edellisen kauden QR-koodi lakkaa toimimasta ${expiredDate}.\n\n${process.env.FRONTEND_BASE_URL ? `${process.env.FRONTEND_BASE_URL}/hae` : 'https://nutakortti.vantaa.fi/hae'}\n\nTerveisin,\nVantaan nuorisopalvelut\n`
+        return `Hei
+
+Nuoren ${recipientName} Mobiilinutakortti odottaa uusimista kaudelle ${this.getSeasonPeriod()}. Alla olevasta linkistä pääset uusimaan nuoren hakemuksen ja päivittämään yhteystiedot. Edellisen kauden QR-koodi lakkaa toimimasta ${moment(expiredDate).format('DD.MM.YYYY')}.
+
+${process.env.FRONTEND_BASE_URL ? `${process.env.FRONTEND_BASE_URL}/hae` : 'https://nutakortti.vantaa.fi/hae'}
+
+Terveisin,
+Vantaan nuorisopalvelut`
     }
 
     private getSeasonPeriod(): string {
-        return `${new Date().getFullYear()} - ${new Date(new Date().setFullYear(new Date().getFullYear() + 1)).getFullYear()}`
+        const currentYear = new Date().getFullYear()
+        const thisTimeNextYear = new Date(new Date().setFullYear(currentYear + 1))
+        const nextYear = thisTimeNextYear.getFullYear()
+
+        return `${currentYear} - ${nextYear}`
     }
 }

--- a/backend/src/sms/sms.service.ts
+++ b/backend/src/sms/sms.service.ts
@@ -87,21 +87,16 @@ export class SmsService {
     }
 
     private getExpiredMessage(recipientName: string, expiredDate: string): string {
-        return `Hei
-
-Nuoren ${recipientName} Mobiilinutakortti odottaa uusimista kaudelle ${this.getSeasonPeriod()}. Alla olevasta linkistä pääset uusimaan nuoren hakemuksen ja päivittämään yhteystiedot. Edellisen kauden QR-koodi lakkaa toimimasta ${moment(expiredDate).format('DD.MM.YYYY')}.
-
-${process.env.FRONTEND_BASE_URL ? `${process.env.FRONTEND_BASE_URL}/hae` : 'https://nutakortti.vantaa.fi/hae'}
-
-Terveisin,
-Vantaan nuorisopalvelut`
+        return "Hei\n\n"
+            + `Nuoren ${recipientName} Mobiilinutakortti odottaa uusimista kaudelle ${this.getSeasonPeriod()}.`
+            + "Alla olevasta linkistä pääset uusimaan nuoren hakemuksen ja päivittämään yhteystiedot."
+            + `Edellisen kauden QR-koodi lakkaa toimimasta ${moment(expiredDate).format('DD.MM.YYYY')}.\n\n`
+            + `${process.env.FRONTEND_BASE_URL ? `${process.env.FRONTEND_BASE_URL}/hae` : 'https://nutakortti.vantaa.fi/hae'}\n\n`
+            + "Terveisin,\nVantaan Nuorisopalvelut"
     }
 
     private getSeasonPeriod(): string {
         const currentYear = new Date().getFullYear()
-        const thisTimeNextYear = new Date(new Date().setFullYear(currentYear + 1))
-        const nextYear = thisTimeNextYear.getFullYear()
-
-        return `${currentYear} - ${nextYear}`
+        return `${currentYear} - ${currentYear + 1}`
     }
 }


### PR DESCRIPTION
Please double check the logic to make sure it work. You can run locally by adding the Telia username / user / password from the production env to docker compose, then change the parent's phone number of all juniors to your work phone (I would suggest local db for easier changes, and not a lot of juniors rows so you don't get spam, since each junior row generate a sms). Finally, comment out the role guard for the endpoint. The test can now be done via Postman