### PR TITLE
add new logic so sms will be sent when edit expired junior to accepted

### DIFF
--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -202,7 +202,7 @@ export class JuniorService {
         }
         await this.juniorRepo.save(user);
         //typeorm doesn't currently return transformed values on save, have to retrieve it again to get the phone number in a correct format
-        if ((prevStatus === 'pending' || prevStatus === 'failedCall') && details.status === 'accepted') {
+        if ((prevStatus === 'expired' || prevStatus === 'pending' || prevStatus === 'failedCall') && details.status === 'accepted') {
             const updatedJunior = await this.getJuniorByPhoneNumber(user.phoneNumber);
             const challenge = await this.setChallenge(updatedJunior.phoneNumber);
             const messageSent = await this.smsService.sendVerificationSMS({ name: updatedJunior.firstName, phoneNumber: updatedJunior.phoneNumber }, challenge);


### PR DESCRIPTION
I review the logic, it seems this is the only change needed to make the expired status play well with the current sms sending logic