### PR TITLE
fix: refresh routes on login

### DIFF
--- a/admin-frontend/src/providers/authProvider.js
+++ b/admin-frontend/src/providers/authProvider.js
@@ -28,6 +28,8 @@ export const authProvider = (type, params) => {
                 } else {
                     localStorage.setItem('role', 'ADMIN');
                 }
+                // Dirty hack; forces recalculation of custom routes based on user role inside App.js
+                window.location.reload();
             })
     }
     if (type === AUTH_ERROR) {


### PR DESCRIPTION
App routes are initialized when the app is initialized, and logout/login
has no effect on these. Therefore, if a youth worker is logged in and
logs out, and an admin logs in on the same browser without reloading the
page, only the routes available for the youth worker are present. The
admin can't access their restricted features despite having them in the
side menu.

Similarly, if an admin is logged in and logs out, a subsequently logged
in youth worker can access the restricted routes (even though) they
aren't visible in the menu.

This commit fixes the issue by force reloading the page after login.
It's a bit of a hack, but the react-admin framework seems to be
extremely opaque and does its best to prevent such route customizations.