### PR TITLE
feat: rename filter label for youth phone number

### DIFF
--- a/admin-frontend/src/components/junior.js
+++ b/admin-frontend/src/components/junior.js
@@ -54,7 +54,7 @@ export const JuniorList = (props) => {
     const JuniorFilter = (props) => (
         <Filter {...props}>
             <TextInput label="Nimi" source="name" autoFocus />
-            <TextInput label="Puhelinnumero" source="phoneNumber" autoFocus />
+            <TextInput label="Nuoren puhelinnumero" source="phoneNumber" autoFocus />
             <TextInput label="Huoltajan puhelinnumero" source="parentsPhoneNumber" autoFocus />
             <SelectInput label="Kotinuorisotila" source="homeYouthClub" choices={youthClubs} />
             <SelectInput label="Tila" source="status" choices={statusChoices} />


### PR DESCRIPTION
The text is changed to "Nuoren puhelinnumero" to make it more explicit
and differentiate it from the guardian's phone number.