### PR TITLE
feat: add contact hours after phone number

### DIFF
--- a/frontend/src/components/ParentRegistration/RegistrationView/index.tsx
+++ b/frontend/src/components/ParentRegistration/RegistrationView/index.tsx
@@ -109,7 +109,7 @@ const RegistrationView: React.FC<RouteComponentProps> = (props) => {
              {error &&
              <Error>
                  <div>
-                 <p>Jokin meni pieleen. Jos virhe toistuu useasti, ole yhteydessä lähinuorisotilaasi tai Mobiilinutakortin yhteyshenkilöön p. +358 400 662739.</p>
+                 <p>Jokin meni pieleen. Jos virhe toistuu useasti, ole yhteydessä lähinuorisotilaasi tai Mobiilinutakortin yhteyshenkilöön p. +358 400 662739 (arkisin 8–16).</p>
                     <Button onClick={() => {
                         //cleans query string if error happened during query string parsing
                         props.history.replace('/hakemus')


### PR DESCRIPTION
If youth card registration fails, the system displays an error message
containing the system contact person's phone number. This commit adds
the appropriate contact hours after the phone number.