### PR TITLE
feat: allow youth card renewal in pending state

### DIFF
--- a/backend/src/content.json
+++ b/backend/src/content.json
@@ -16,7 +16,7 @@
   "NoNewCheckins": "Ei kirjautumisia.",
   "NotADate": "Väärä päivämäärä.",
   "JuniorAlreadyExists": "Käyttäjätili on jo luotu tällä puhelinnumerolla.",
-  "JuniorNotExpired": "Uusittava jäsenkortti ei ole vanhentunut.",
+  "JuniorNotExpiredOrPending": "Uusittava jäsenkortti ei ole tilassa \"tunnus vanhentunut\" tai \"kotisoitto tekemättä\".",
   "LockedOut": "Liian monta väärää yritystä.",
   "Reset": "Palautuslinkki lähetetty.",
   "Updated": "Päivitetty.",

--- a/backend/src/junior/junior.service.ts
+++ b/backend/src/junior/junior.service.ts
@@ -139,14 +139,14 @@ export class JuniorService {
         if (existingJunior) {
             this.logger.log(`Found existing junior with ID ${existingJunior.id}, phone ${existingJunior.phoneNumber}, status ${existingJunior.status}`)
 
-            // Only allow account renewal if existing junior's status is expired
-            if (existingJunior.status === "expired") {
-                this.logger.log(`Overwriting expired junior ${existingJunior.phoneNumber} with registration form data`)
+            // Only allow account renewal if existing junior's status is expired or pending
+            if (["expired", "pending"].includes(existingJunior.status)) {
+                this.logger.log(`Overwriting junior ${existingJunior.phoneNumber} with registration form data`)
                 junior = existingJunior
                 renew = true
             } else {
-                this.logger.error(`Unable to overwrite existing junior ${existingJunior.phoneNumber}, because status is not expired.`)
-                throw new ConflictException(content.JuniorNotExpired);
+                this.logger.error(`Unable to overwrite existing junior ${existingJunior.phoneNumber}, because status is not expired or pending.`)
+                throw new ConflictException(content.JuniorNotExpiredOrPending);
             }
         } else {
             this.logger.log('Existing junior not found, attempting to create a new junior with registration form data')


### PR DESCRIPTION
Previously guardians have inadvertently tried to register their youths
multiple times. If the youth card was registered succesfully but not yet
accepted, any subsequent registration attempts have been met with a
non-descriptive error message, which has resulted in confusion and calls
to the Nutakortti contact person and youth clubs.

After this change guardians can register the same youth multiple times
as long as the youth's status is either "expired / tunnus vanhentunut"
or "pending / kotisoitto tekemättä". This will just overwrite the
existing youth with the provided registration form data. It is still not
possible to overwrite data for youths with any other status.