### PR TITLE
fix: reuse same regexp for all phone number validations

### DIFF
--- a/backend/src/junior/pipes/constants.ts
+++ b/backend/src/junior/pipes/constants.ts
@@ -1,0 +1,1 @@
+export const allowedPhoneNumber = /(^(\+358|0|358)\d{6,10}$)/;

--- a/backend/src/junior/pipes/phoneNumberValidation.pipe.ts
+++ b/backend/src/junior/pipes/phoneNumberValidation.pipe.ts
@@ -1,9 +1,10 @@
 import { PipeTransform, BadRequestException } from '@nestjs/common';
+import { allowedPhoneNumber } from './constants';
 import * as content from '../../content.json';
 
 // Custom pipe for handling "phoneNumber" and "parentsPhoneNumber" validation while adding/editing junior details
 export class PhoneNumberValidationPipe implements PipeTransform {
-  readonly allowedPhoneNumber = /(^(\+358|0|358)\d{6,10}$)/;
+  readonly allowedPhoneNumber = allowedPhoneNumber
 
   transform(value: any) {
     const { phoneNumber, parentsPhoneNumber, userData } = value;

--- a/backend/src/junior/pipes/phoneNumberValidation.spec.ts
+++ b/backend/src/junior/pipes/phoneNumberValidation.spec.ts
@@ -1,0 +1,131 @@
+import { PhoneNumberValidationPipe } from './phoneNumberValidation.pipe';
+import { ResetPhoneNumberValidationPipe } from './resetPhoneNumberValidation.pipe';
+
+const generateMockPhoneNumbers = (length: number): string[] =>
+  Array.from({ length }, () => '7'.repeat(length));
+
+describe('Phone number validation', () => {
+  const validPrefixes = ['0', '358', '+358'];
+  const validLengths = [6, 7, 8, 9, 10];
+  const validNumbers: string[] = [].concat(
+    ...validLengths.map(generateMockPhoneNumbers),
+  );
+
+  describe('PhoneNumberValidationPipe', () => {
+    const validationPipe = new PhoneNumberValidationPipe();
+
+    it('passes valid phone numbers', () => {
+      for (let prefix of validPrefixes) {
+        for (let validNumber of validNumbers) {
+          const phoneNumber = `${prefix}${validNumber}`;
+          const value = {
+            phoneNumber,
+            parentsPhoneNumber: phoneNumber,
+          };
+          expect(validationPipe.transform(value)).toBe(value);
+          expect(validationPipe.transform({ userData: value })).toEqual({
+            userData: value,
+          });
+        }
+      }
+    });
+
+    it('rejects invalid phone numbers', () => {
+      // Incorrect length
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '050777',
+          parentsPhoneNumber: '358507777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          userData: {
+            phoneNumber: '050777',
+            parentsPhoneNumber: '358507777',
+          },
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '+358507777',
+          parentsPhoneNumber: '050777',
+        }),
+      ).toThrow('Huoltajan puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          userData: {
+            phoneNumber: '+358507777',
+            parentsPhoneNumber: '050777',
+          },
+        }),
+      ).toThrow('Huoltajan puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '050777777777',
+          parentsPhoneNumber: '358507777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '+358507777',
+          parentsPhoneNumber: '050777777777',
+        }),
+      ).toThrow('Huoltajan puhelinnumero on virheellinen');
+
+      // Incorrect prefix
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '357507777',
+          parentsPhoneNumber: '0507777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '0507777',
+          parentsPhoneNumber: '+359507777',
+        }),
+      ).toThrow('Huoltajan puhelinnumero on virheellinen');
+    });
+  });
+
+  describe('ResetPhoneNumberValidationPipe', () => {
+    const validationPipe = new ResetPhoneNumberValidationPipe();
+
+    it('passes valid phone numbers', () => {
+      for (let prefix of validPrefixes) {
+        for (let validNumber of validNumbers) {
+          const phoneNumber = `${prefix}${validNumber}`;
+          const value = { phoneNumber };
+          expect(validationPipe.transform(value)).toBe(value);
+        }
+      }
+    });
+
+    it('rejects invalid phone numbers', () => {
+      // Incorrect length
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '050777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '050777777777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+
+      // Incorrect prefix
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '357507777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+      expect(() =>
+        validationPipe.transform({
+          phoneNumber: '+357507777',
+        }),
+      ).toThrow('Puhelinnumero on virheellinen');
+    });
+  });
+});

--- a/backend/src/junior/pipes/resetPhoneNumberValidation.pipe.ts
+++ b/backend/src/junior/pipes/resetPhoneNumberValidation.pipe.ts
@@ -1,9 +1,10 @@
 import { PipeTransform, BadRequestException } from "@nestjs/common";
+import { allowedPhoneNumber } from "./constants";
 import * as content from '../../content.json';
 
 // Custom pipe for handling "phoneNumber" validation while resending SMS
 export class ResetPhoneNumberValidationPipe implements PipeTransform {
-  readonly allowedPhoneNumber = /(^(\+358|0|358)\d{9}$)/;
+  readonly allowedPhoneNumber = allowedPhoneNumber
 
   transform(value: any) {
     const { phoneNumber } = value;


### PR DESCRIPTION
When the phone number regexp was updated for the
PhoneNumberValidationPipe, the ResetPhoneNumberValidationPipe's separate
regexp was left as-is. This commit refactors the regexp outside the
PhoneNumberValidationPipe class and imports the same value to both pipes.
Unit tests were also added to ensure that both validation pipes behave
identically for the same phone numbers.