### PR TITLE
Use a correct API endpoint in the self-contained Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/$TZ /etc/localtime
 ADD ./backend /backend
 ADD ./frontend /frontend
 WORKDIR /frontend
-RUN npm ci && npm run build && cp -r ./build ../backend/public
+RUN npm ci && REACT_APP_ENDPOINT=/api npm run build && cp -r ./build ../backend/public
 ADD ./admin-frontend /admin-frontend
 WORKDIR /admin-frontend
-RUN npm ci && npm run build && cp -r ./build ../backend/public-admin
+RUN npm ci && REACT_APP_ENDPOINT=/api npm run build && cp -r ./build ../backend/public-admin
 WORKDIR /backend
 RUN npm ci && npm run build
 EXPOSE 3000


### PR DESCRIPTION
Previously, the frontends always requested the default Vantaa endpoint.